### PR TITLE
Add new element (Raw Image, some delegates events and methods) to avoid use of byte[]

### DIFF
--- a/src/MediaEndPoints.cs
+++ b/src/MediaEndPoints.cs
@@ -7,11 +7,14 @@ using System.Threading.Tasks;
 namespace SIPSorceryMedia.Abstractions
 {
     public delegate void EncodedSampleDelegate(uint durationRtpUnits, byte[] sample);
-    
+
     public delegate void RawAudioSampleDelegate(AudioSamplingRatesEnum samplingRate, uint durationMilliseconds, short[] sample);
-    
-    public delegate void RawVideoSampleDelegate(uint durationMilliseconds, RawImage rawImage);
-    public delegate void VideoSinkSampleDecodedDelegate(RawImage rawImage);
+
+    public delegate void RawVideoSampleDelegate(uint durationMilliseconds, int width, int height, byte[] sample, VideoPixelFormatsEnum pixelFormat);
+    public delegate void VideoSinkSampleDecodedDelegate(byte[] sample, uint width, uint height, int stride, VideoPixelFormatsEnum pixelFormat);
+
+    public delegate void RawVideoSampleFasterDelegate(uint durationMilliseconds, RawImage rawImage); // Avoid to use byte[] to improve performance
+    public delegate void VideoSinkSampleDecodedFasterDelegate(RawImage rawImage); // Avoid to use byte[] to improve performance
 
     public delegate void SourceErrorDelegate(string errorMessage);
 
@@ -481,7 +484,7 @@ namespace SIPSorceryMedia.Abstractions
         {
             byte[] result = null;
 
-            if ( (Height > 0) && (Stride > 0) && (Sample != null) )
+            if ((Height > 0) && (Stride > 0))
             {
                 var bufferSize = Height * Stride;
 
@@ -492,6 +495,12 @@ namespace SIPSorceryMedia.Abstractions
         }
     }
 
+    public struct VideoSample
+    {
+        public uint Width;
+        public uint Height;
+        public byte[] Sample;
+    }
 
     public interface IVideoEncoder : IDisposable
     {
@@ -500,11 +509,15 @@ namespace SIPSorceryMedia.Abstractions
         /// </summary>
         List<VideoFormat> SupportedFormats { get; }
 
-        byte[] EncodeVideo(RawImage rawImage, VideoCodecsEnum codec);
+        byte[] EncodeVideo(int width, int height, byte[] sample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec);
+
+        byte[] EncodeVideoFaster(RawImage rawImage, VideoCodecsEnum codec); // Avoid to use byte[] to improve performance
 
         void ForceKeyFrame();
 
-        IEnumerable<RawImage> DecodeVideo(byte[] encodedSample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec);
+        IEnumerable<VideoSample> DecodeVideo(byte[] encodedSample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec);
+
+        IEnumerable<RawImage> DecodeVideoFaster(byte[] encodedSample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec); // Avoid to use byte[] to improve performance
     }
 
     public interface IAudioSource
@@ -563,6 +576,8 @@ namespace SIPSorceryMedia.Abstractions
 
         event RawVideoSampleDelegate OnVideoSourceRawSample;
 
+        event RawVideoSampleFasterDelegate OnVideoSourceRawSampleFaster; // Avoid to use byte[] to improve performance
+
         event SourceErrorDelegate OnVideoSourceError;
 
         Task PauseVideo();
@@ -579,7 +594,9 @@ namespace SIPSorceryMedia.Abstractions
 
         void RestrictFormats(Func<VideoFormat, bool> filter);
 
-        void ExternalVideoSourceRawSample(uint durationMilliseconds, RawImage rawImage);
+        void ExternalVideoSourceRawSample(uint durationMilliseconds, int width, int height, byte[] sample, VideoPixelFormatsEnum pixelFormat);
+
+        void ExternalVideoSourceRawSampleFaster(uint durationMilliseconds, RawImage rawImage); // Avoid to use byte[] to improve performance
 
         void ForceKeyFrame();
 
@@ -594,6 +611,8 @@ namespace SIPSorceryMedia.Abstractions
         /// This event will be fired by the sink after is decodes a video frame from the RTP stream.
         /// </summary>
         event VideoSinkSampleDecodedDelegate OnVideoSinkDecodedSample;
+
+        event VideoSinkSampleDecodedFasterDelegate OnVideoSinkDecodedSampleFaster; // Avoid to use byte[] to improve performance
 
         void GotVideoRtp(IPEndPoint remoteEndPoint, uint ssrc, uint seqnum, uint timestamp, int payloadID, bool marker, byte[] payload);
 

--- a/src/MediaEndPoints.cs
+++ b/src/MediaEndPoints.cs
@@ -579,7 +579,7 @@ namespace SIPSorceryMedia.Abstractions
 
         void RestrictFormats(Func<VideoFormat, bool> filter);
 
-        void ExternalVideoSourceRawSample(uint durationMilliseconds, int width, int height, byte[] sample, VideoPixelFormatsEnum pixelFormat);
+        void ExternalVideoSourceRawSample(uint durationMilliseconds, RawImage rawImage);
 
         void ForceKeyFrame();
 

--- a/src/SIPSorceryMedia.Abstractions.csproj
+++ b/src/SIPSorceryMedia.Abstractions.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <PackageId>SIPSorceryMedia.Abstractions</PackageId>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020 Aaron Clauson</Copyright>
@@ -21,12 +21,13 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/sipsorcery/SIPSorceryMedia.Abstractions</RepositoryUrl>
-    <Version>1.1.0.1</Version>
-    <AssemblyVersion>1.1.0.1</AssemblyVersion>
-    <FileVersion>1.1.0.1</FileVersion>
+    <Version>1.1.0.2</Version>
+    <AssemblyVersion>1.1.0.2</AssemblyVersion>
+    <FileVersion>1.1.0.2</FileVersion>
     <RepositoryBranch>master</RepositoryBranch>
     <PackageTags>WebRTC VoIP SIPSorcery Media</PackageTags>
-    <PackageReleaseNotes>-v1.1.0.1: Use RawImage instead of VideoSample (to use IntPtr instead of byte[])
+    <PackageReleaseNotes>-v1.1.0.2: IVideoSource.ExternalVideoSourceRawSample must also use RawImage
+-v1.1.0.1: Use RawImage instead of VideoSample (to use IntPtr instead of byte[])
 -v1.1.0: Stable release.
 -v1.0.4-pre: Changed IAudioEncoder and IVideoEncoder to use SupportedFormats property instead of IsSupported method.
 -v1.0.3-pre: Added video format to IVideoSink.GotVideoFrame. Removed 'V1' from namespace, the versioning mechanism is not going to be suitable for such a formative API.

--- a/src/SIPSorceryMedia.Abstractions.csproj
+++ b/src/SIPSorceryMedia.Abstractions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>SIPSorceryMedia.Abstractions</PackageId>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020 Aaron Clauson</Copyright>

--- a/src/SIPSorceryMedia.Abstractions.csproj
+++ b/src/SIPSorceryMedia.Abstractions.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-  </ItemGroup>
-
   <PropertyGroup>
     <PackageId>SIPSorceryMedia.Abstractions</PackageId>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020 Aaron Clauson</Copyright>
@@ -21,13 +17,13 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/sipsorcery/SIPSorceryMedia.Abstractions</RepositoryUrl>
-    <Version>1.1.0.2</Version>
-    <AssemblyVersion>1.1.0.2</AssemblyVersion>
-    <FileVersion>1.1.0.2</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <FileVersion>1.2.0</FileVersion>
     <RepositoryBranch>master</RepositoryBranch>
     <PackageTags>WebRTC VoIP SIPSorcery Media</PackageTags>
-    <PackageReleaseNotes>-v1.1.0.2: IVideoSource.ExternalVideoSourceRawSample must also use RawImage
--v1.1.0.1: Use RawImage instead of VideoSample (to use IntPtr instead of byte[])
+    <PackageReleaseNotes>
+-v1.2.0: Add RawImage and new events / methods to avoid the use of byte[] to improve performance
 -v1.1.0: Stable release.
 -v1.0.4-pre: Changed IAudioEncoder and IVideoEncoder to use SupportedFormats property instead of IsSupported method.
 -v1.0.3-pre: Added video format to IVideoSink.GotVideoFrame. Removed 'V1' from namespace, the versioning mechanism is not going to be suitable for such a formative API.
@@ -38,6 +34,10 @@
 
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
To be coherent, IVideoSource.ExternalVideoSourceRawSample must also use RawImage

Bump to version 1.1.0.2