### PR TITLE
Enable generation of SIPSorceryMedia.Abstractions.xml documentation file

### DIFF
--- a/src/MediaFormatManager.cs
+++ b/src/MediaFormatManager.cs
@@ -24,7 +24,7 @@ namespace SIPSorceryMedia.Abstractions
 
         /// <summary>
         /// Requests that the audio sink and source only advertise support for the supplied list of codecs.
-        /// Only codecs that are already supported and in the <see cref="SupportedCodecs" /> list can be 
+        /// Only codecs that are already supported and in the <see cref="SupportedFormats" /> list can be 
         /// used.
         /// </summary>
         /// <param name="filter">Function to determine which formats the source formats should be restricted to.</param>

--- a/src/SIPSorceryMedia.Abstractions.csproj
+++ b/src/SIPSorceryMedia.Abstractions.csproj
@@ -4,6 +4,9 @@
     <PackageId>SIPSorceryMedia.Abstractions</PackageId>
     <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Disable warning for missing XML doc comments. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <Authors>Aaron Clauson</Authors>
     <Copyright>Copyright © 2020 Aaron Clauson</Copyright>
     <Company>SIP Sorcery PTY LTD</Company>


### PR DESCRIPTION
Same thing as https://github.com/sipsorcery-org/sipsorcery/pull/1106

* Enabled GenerateDocumentationFile in SIPSorcery.csproj
* Disabled the "missing XML comment" warnings