### PR TITLE
Update AudioFormat.cs

### DIFF
--- a/src/MediaFormats/AudioFormat.cs
+++ b/src/MediaFormats/AudioFormat.cs
@@ -171,7 +171,7 @@ public struct AudioFormat
         Parameters = parameters;
         _isNonEmpty = true;
 
-        if (Enum.TryParse<AudioCodecsEnum>(FormatName, out var audioCodec))
+        if (Enum.TryParse<AudioCodecsEnum>(FormatName.ToUpper(), out var audioCodec))
         {
             Codec = audioCodec;
         }


### PR DESCRIPTION
Chrome sends through "opus" which fails to parse to OPUS audio codec. All codecs are in upper case in the code.